### PR TITLE
Add graveyard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # discord-eraser
+
 xx日後に消えるチャンネル
 
-
 .env
+
 ```
 CATEGORY_ID=XXXXXX
 DISCORD_BOT_TOKEN=XXXXXX
+GRAVEYARD_CHANNEL_ID=XXXXXX
 ```

--- a/index.mjs
+++ b/index.mjs
@@ -1,15 +1,17 @@
 import {
+  AttachmentBuilder,
   Client,
+  Collection,
   GatewayIntentBits
 } from 'discord.js';
 import { configDotenv } from 'dotenv';
 import fs from 'fs';
-import cron from 'node-cron';
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.GuildModeration,
+    GatewayIntentBits.MessageContent,
   ],
 });
 configDotenv();
@@ -26,6 +28,35 @@ async function resetChannel(guildId, channelId) {
   const guild = await client.guilds.fetch(guildId).catch(console.error);
   const channel = await guild.channels.fetch(channelId).catch(console.error);
   if (channel) {
+    // チャンネルを削除する前にメッセージを取得できる限りすべて取得する
+    let messages = [];
+    let lastId;
+    try {
+      do {
+        const fetchedMessages = await fetchMany(channel, { limit: 100, ...(lastId ? { before: lastId } : {}) });
+        if (fetchedMessages.size > 0) {
+          messages = [...messages, ...fetchedMessages.values()];
+          lastId = fetchedMessages.last().id;
+        } else {
+          break;
+        }
+      } while (messages.length < 10000);
+    } catch (error) {
+      console.error(error);
+    }
+    // メッセージから投稿ユーザー名、タイムスタンプ、メッセージ内容を抽出してテキストファイルに保存する
+    const text = messages.map(message => `${message.author.username} ${message.createdAt} ${message.content}`).join('\n');
+    // テキストをローカルファイルに保存する
+    fs.writeFileSync('messages.txt', text);
+    const text_file = new AttachmentBuilder('./messages.txt', { name: 'messages.txt' });
+
+    // テキストファイルをDiscordの墓場チャンネルに投稿する
+    const graveyardChannel = await guild.channels.fetch(process.env.GRAVEYARD_CHANNEL_ID).catch(console.error);
+    if (graveyardChannel) {
+      graveyardChannel.send({ content: `Channel ${channel.name} in guild ${guild.name} has been reset.`, files: [text_file] });
+    }
+
+    // チャンネルをリセットする
     const pos = channel.position;
     const newChannel = await channel.clone();
 
@@ -91,3 +122,54 @@ client.on("channelUpdate", (oldChannel, newChannel) => {
 });
 
 client.login(process.env.DISCORD_BOT_TOKEN);
+
+
+function array2Collection(messages) {
+  return new Collection(messages.slice().sort((a, b) => {
+    const a_id = BigInt(a.id);
+    const b_id = BigInt(b.id);
+    return (a_id > b_id ? 1 : (a_id === b_id ? 0 : -1));
+  }).map(e => [e.id, e]));
+}
+
+// メッセージを100件以上取得するための関数
+async function fetchMany(channel, options = { limit: 50 }) {
+  if ((options.limit ?? 50) <= 100) {
+    return channel.messages.fetch(options);
+  }
+
+  if (typeof options.around === "string") {
+    const messages = await channel.messages.fetch({ ...options, limit: 100 });
+    const limit = Math.floor((options.limit - 100) / 2);
+    if (messages.size < 100) {
+      return messages;
+    }
+    const backward = fetchMany(channel, { limit, before: messages.last().id });
+    const forward = fetchMany(channel, { limit, after: messages.first().id });
+    return array2Collection([messages, ...await Promise.all([backward, forward])].flatMap(
+      e => [...e.values()]
+    ));
+  }
+  let temp;
+  function buildParameter() {
+    const req_cnt = Math.min(options.limit - messages.length, 100);
+    if (typeof options.after === "string") {
+      const after = temp
+        ? temp.first().id : options.after
+      return { ...options, limit: req_cnt, after };
+    }
+    const before = temp
+      ? temp.last().id : options.before;
+    return { ...options, limit: req_cnt, before };
+  }
+  const messages = [];
+  while (messages.length < options.limit) {
+    const param = buildParameter();
+    temp = await channel.messages.fetch(param);
+    messages.push(...temp.values());
+    if (param.limit > temp.size) {
+      break;
+    }
+  }
+  return array2Collection(messages);
+}


### PR DESCRIPTION
- いつか消えるチャンネルが消えたときに墓場チャンネルに全メッセージ(10,000件まで)をtxtファイルに出力してアップロードする処理を追加しました。
- 墓場チャンネルは一時的な置き場で非公開想定です。
![image](https://github.com/sngazm/discord-eraser/assets/33051481/dd700153-27e0-43f9-a90b-ffe360ed833d)
